### PR TITLE
Bump poi from 4.1.0 to 4.1.1 in /servers

### DIFF
--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>4.1.0</version>
+			<version>4.1.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml -->
 		<dependency>


### PR DESCRIPTION
Bumps poi from 4.1.0 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>